### PR TITLE
Update linkedin profile photos

### DIFF
--- a/content/radars/2020-09-observability.yml
+++ b/content/radars/2020-09-observability.yml
@@ -21,7 +21,7 @@ themes:
 video: https://www.youtube.com/embed/I44EepyZGNo      
 team:
   - name: Jon Moter
-    photo: https://media-exp1.licdn.com/dms/image/C4E03AQFTKuqDY0pAgQ/profile-displayphoto-shrink_800_800/0?e=1605139200&v=beta&t=Xc7d5pFfgmk6Sz0ECN0vowegzrlj8KFgOKw54UnRbHs
+    photo: https://media-exp1.licdn.com/dms/image/C4E03AQFTKuqDY0pAgQ/profile-displayphoto-shrink_800_800/0/1516159058594?e=1611187200&v=beta&t=0F0yo8iAY-UkrIKM8e__4umXQpDPa6-vHbvlyQloUQs
     bio: |
       Jon works in the Foundation Engineering organization, which provides compute, storage, and cloud infrastructure to the rest of Zendesk engineering.
     twitter: jonmoter
@@ -40,7 +40,7 @@ team:
     linkedin: marcinsuterski
     title: Lead Engineer at The New York Times
   - name: Jason Tarasovic
-    photo: https://media-exp1.licdn.com/dms/image/C5603AQHbfD1J8xwmJA/profile-displayphoto-shrink_400_400/0?e=1605139200&v=beta&t=76SuCoPOkfiraifrNcX0SUkAkCyVRujiCi64ywXm5io
+    photo: https://media-exp1.licdn.com/dms/image/C5603AQHbfD1J8xwmJA/profile-displayphoto-shrink_800_800/0?e=1611187200&v=beta&t=LbiiyAA5_vvjcMqovIyvdPEEIIeObYJmHUgLQ5uPfkI
     bio: |
       Jason was the founding engineer for the Platform Engineering team, where he was responsible for building and running their cloud native platform.
     twitter: J_Tarasovic


### PR DESCRIPTION
URLs for LinkedIn profile photos seem to have changed, causing a failure when building on Netlify.