### PR TITLE
Radar customisation

### DIFF
--- a/content/radars/2021-02-secrets-management.yml
+++ b/content/radars/2021-02-secrets-management.yml
@@ -137,8 +137,6 @@ companies:
     industry: Academia
   - landscapeId: lunar-supporter
     industry: Financial Services
-  - landscapeId: price-spider-supporter
-    industry: E-commerce
   - landscapeId: pro-sieben-sat-1-supporter
     industry: Broadcasting
   - landscapeId: pay-it-supporter

--- a/content/radars/2021-09-devsecops.yml
+++ b/content/radars/2021-09-devsecops.yml
@@ -150,8 +150,6 @@ companies:
     industry: Software
   - landscapeId: post-finance-supporter
     industry: Financial Services
-  - landscapeId: discover-financial-services-supporter
-    industry: Financial Services
   - landscapeId: u-pchieve-member
     industry: Education
   - landscapeId: zalando-supporter

--- a/content/settings.js
+++ b/content/settings.js
@@ -18,5 +18,22 @@ module.exports = {
         CNCF relies exclusively on established Enterprise Open Source technologies. This leads to innovative
         solutions, digital products and portals in agile software projects, and helps build long-lasting, strategic
         partnerships with our customers.`
+    },
+    levels: [
+        "adopt",
+        "trial",
+        "assess",
+        "hold",
+    ],
+    radar_levels: [
+        "adopt",
+        "trial",
+        "assess",
+    ],
+    level_names: {
+        "adopt": "Adopt",
+        "trial": "Trial",
+        "assess": "Assess",
+        "hold": "Hold",
     }
 }

--- a/content/styles.config.js
+++ b/content/styles.config.js
@@ -24,5 +24,11 @@ module.exports = {
   sizes: {
     mobile: 768,
     tablet: 1024
+  },
+  backgrounds: {
+    "adopt": "adoptBg",
+    "trial": "trialBg",
+    "assess": "assessBg",
+    "hold": "holdBg",
   }
 }

--- a/src/components/LevelTag.js
+++ b/src/components/LevelTag.js
@@ -1,10 +1,4 @@
-import { colors } from '../styles.config'
-
-const levelMap = {
-  adopt: 'Adopt',
-  assess: 'Assess',
-  trial: 'Trial'
-}
+import { level_names } from "../settings"
 
 export default function LevelTag({ level, style, text, className }) {
   return <span className={`tag ${className} ${level}-background`} style={{ ...style }}>
@@ -14,6 +8,6 @@ export default function LevelTag({ level, style, text, className }) {
         color: #202020 !important;
       }
     `}</style>
-    {levelMap[level] || text}
+    {level_names[level] || text}
   </span>
 }

--- a/src/components/Radar.js
+++ b/src/components/Radar.js
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 import { colors, typography } from '../styles.config'
 import groupPoints from '../helpers/groupPoints'
 import SelectedPointContext from '../contexts/SelectedPointContext'
-import { short_ident } from '../settings'
+import { level_names, radar_levels, short_ident } from '../settings'
 
 const { fontFamily } = typography
 
@@ -84,18 +84,25 @@ const Header = props => {
 export default function Radar({ points, title, subtitle, showHeader = false }) {
   const groupedPoints = groupPoints(points)
 
+  const radarHeight = 250 * (radar_levels.length + 1)
+  const radarWidth = radarHeight * Math.cos(Math.PI / 6) * 2
+
   const padding = showHeader ? 30 : 0
-  const width = 1740 + padding * 2
-  const height = 1006 + (showHeader ? 90 : 0) + (showHeader && subtitle ? 20 : 0) + padding * 2
+  const width = radarWidth + padding * 2
+  const height = radarHeight + 6 + (showHeader ? 90 : 0) + (showHeader && subtitle ? 20 : 0) + padding * 2
+
+  const rings = [...radar_levels].reverse().map((level, idx) => {
+    const radius = 500 + (idx * 250)
+    const inner = radius == 500 ? 0 : (radius - 250)
+    return <Ring radius={radius} minRadius={inner} points={groupedPoints[level]} title={level_names[level]} color={colors[level + 'Bg']} />
+  }).reverse()
 
   return <svg viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg" dominantBaseline="central" textAnchor="middle" fontFamily={fontFamily}>
     { showHeader && <Header textAnchor="start" x={padding} y={padding}>{ short_ident } Technology Radar</Header> }
     { showHeader && <Header textAnchor="end" x={width - padding} y={padding}>{title}</Header> }
     { showHeader && subtitle && <Header textAnchor="end" x={width - padding} y={padding + 60}>{subtitle}</Header> }
     <g transform={`translate(${width / 2} ${height - padding - 3})`}>
-      <Ring radius={1000} minRadius={750} points={groupedPoints.assess} title="Assess" color={colors.assessBg} />
-      <Ring radius={750} minRadius={500} points={groupedPoints.trial} title="Trial" color={colors.trialBg} />
-      <Ring radius={500} minRadius={0} points={groupedPoints.adopt} title="Adopt" color={colors.adoptBg} />
+      {rings}
     </g>
   </svg>
 }

--- a/src/components/RadarData.js
+++ b/src/components/RadarData.js
@@ -2,6 +2,13 @@ import { Fragment } from 'react'
 import groupPoints from '../helpers/groupPoints'
 import LinkToPoint from './LinkToPoint'
 import { colors } from '../styles.config'
+import { levels, radar_levels, level_names } from '../settings'
+
+function comparePoints(a,b) {
+  return levels
+    .map(level => (b.votes[level] || 0) - (a.votes[level] || 0))
+    .reduce((prev,next) => prev || next)
+}
 
 export default function RadarData({ points, companies }) {
   const groupedPoints = groupPoints(points)
@@ -65,13 +72,8 @@ export default function RadarData({ points, companies }) {
       <div className="header item-level">Votes</div>
 
       {
-        ['adopt', 'trial', 'assess'].map(level => {
-          const sortedPoints = groupedPoints[level].sort((a, b) => {
-            return ((b.votes.adopt || 0) - (a.votes.adopt || 0)) ||
-              ((b.votes.trial || 0) - (a.votes.trial || 0)) ||
-              ((b.votes.assess || 0) - (a.votes.assess || 0)) ||
-              ((b.votes.hold || 0) - (a.votes.hold || 0))
-          })
+        radar_levels.map(level => {
+          const sortedPoints = groupedPoints[level].sort(comparePoints)
 
           return sortedPoints.map((point, i) => {
             return <Fragment key={`point-${level}-${point.fullKey}`}>
@@ -83,7 +85,7 @@ export default function RadarData({ points, companies }) {
               <div className="item"><LinkToPoint point={point} /> {repeatedPoints[point.key] ? `(${point.subradar.name})` : ''}</div>
               <div className="item">
                 {
-                  ['adopt', 'trial', 'assess', 'hold'].map(voteKey => {
+                  levels.map(voteKey => {
                     const votes = point.votes[voteKey]
 
                     if (!votes) {

--- a/src/helpers/groupPoints.js
+++ b/src/helpers/groupPoints.js
@@ -1,9 +1,11 @@
+import { radar_levels } from "../settings"
+
 const groupPoints = points => {
-  return {
-    adopt: points.filter(point => point.level === 'adopt'),
-    trial: points.filter(point => point.level === 'trial'),
-    assess: points.filter(point => point.level === 'assess')
-  }
+  return Object.assign({},
+    ...radar_levels.map(
+      level => ({[level]: points.filter(point => point.level === level)})
+    )
+  )
 }
 
 export default groupPoints

--- a/src/helpers/markdownToHtml.js
+++ b/src/helpers/markdownToHtml.js
@@ -2,6 +2,7 @@ import ReactDOMServer from 'react-dom/server'
 import { Converter } from 'showdown'
 import sanitizeHtml from 'sanitize-html'
 import LevelTag from '../components/LevelTag'
+import { level_names } from '../settings'
 
 const renderLevelTag = level => ReactDOMServer.renderToString(<dt><LevelTag level={level} className="is-medium" /></dt>)
 
@@ -28,10 +29,10 @@ export default text => {
     return text
   }
   const html = new Converter({ simpleLineBreaks: false }).makeHtml(text)
-  const sanitizedHtml = sanitizeHtml(html, { allowedTags, allowedAttributes, transformTags })
-    .replace('<dt>Adopt</dt>', renderLevelTag('adopt'))
-    .replace('<dt>Trial</dt>', renderLevelTag('trial'))
-    .replace('<dt>Assess</dt>', renderLevelTag('assess'))
-
+  var sanitizedHtml = sanitizeHtml(html, { allowedTags, allowedAttributes, transformTags })
+  for (var label in level_names) {
+    const repl = `<dt>${level_names[label]}</dt>`
+    sanitizedHtml = sanitizedHtml.replace(repl, renderLevelTag(label))
+  }
   return sanitizedHtml
 }

--- a/src/schemas/RadarSchema.js
+++ b/src/schemas/RadarSchema.js
@@ -1,5 +1,6 @@
 import * as yup from 'yup'
 import markdownToHtml from '../helpers/markdownToHtml'
+import { levels } from '../settings'
 
 const themeSchema = yup.object({
   headline: yup.string()
@@ -23,20 +24,9 @@ const memberSchema = yup.object({
   linkedin: yup.string(),
 })
 
-const votesSchema = yup.object({
-  adopt: yup.number()
-    .integer()
-    .min(1),
-  trial: yup.number()
-    .integer()
-    .min(1),
-  assess: yup.number()
-    .integer()
-    .min(1),
-  hold: yup.number()
-    .integer()
-    .min(1),
-})
+const votesSchema = yup.object(
+  Object.assign({}, ...levels.map(level => ({[level]: yup.number().integer().min(1)})))
+)
 
 const pointSchema = yup.object({
   name: yup.string()
@@ -45,7 +35,7 @@ const pointSchema = yup.object({
     .url(),
   repo: yup.string(),
   level: yup.string()
-    .oneOf(['adopt', 'trial', 'assess', 'hold'])
+    .oneOf(levels)
     .required(),
   votes: votesSchema
     .required()

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -95,20 +95,10 @@ ol {
   margin-left: 1.5rem;
 }
 
-body .adopt-background {
-  background-color: map.get($colors, 'adoptBg');
-}
-
-body .trial-background {
-  background-color: map.get($colors, 'trialBg');
-}
-
-body .assess-background {
-  background-color: map.get($colors, 'assessBg');
-}
-
-body .hold-background {
-  background-color: map.get($colors, 'holdBg');
+@each $background, $color in $backgrounds {
+  body .#{$background}-background {
+    background-color: map.get($colors, $color);
+  }
 }
 
 .table {


### PR DESCRIPTION
This branch does a company cleanup chore, and then introduces a refactor which permits radar settings to control the number, name, color, and labels, of the levels in the radars.  Some companies use different schemes for technology radars and this way it is configurable.

I have done my best to ensure that things are the same for the CNCF radars.  The SVGs are a few pixels different in size because previously they had been human-rounded whereas now they're mathematically chosen.