### PR TITLE
Suggested reference update to Xray spelling and homepage

### DIFF
--- a/content/radars/2021-09-devsecops.yml
+++ b/content/radars/2021-09-devsecops.yml
@@ -51,8 +51,8 @@ points:
     votes:
       adopt: 13
       trial: 2
-  - name: XRay
-    homepage: https://www.getxray.app/
+  - name: Xray
+    homepage: https://www.jfrog.com/confluence/display/JFROG/JFrog+Xray
     level: trial
     votes:
       adopt: 1


### PR DESCRIPTION
Was the reference to XRay [https://github.com/cncf/radar/search?q=xray](https://github.com/cncf/radar/search?q=xray) meant to be [JFrog Xray](https://www.jfrog.com/confluence/display/JFROG/JFrog+Xray) the DevSecOps SCA toolset used with Artifactory in the Adopt range instead of [XRay (an Idera Company)](https://www.getxray.app/)?

Additional context: [https://sunday.fudge.org/p/underneath-the-cncf-tech-radar](https://sunday.fudge.org/p/underneath-the-cncf-tech-radar)

Signed-off-by: Jay Cuthrell <jay@cuthrell.com>

